### PR TITLE
More suitable slashing parameters

### DIFF
--- a/coral/config/genesis.json
+++ b/coral/config/genesis.json
@@ -186,8 +186,8 @@
       "missed_blocks": {},
       "params": {
         "downtime_jail_duration": "600000000000",
-        "min_signed_per_window": "0.500000000000000000",
-        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.050000000000000000",
+        "signed_blocks_window": "10000",
         "slash_fraction_double_sign": "0.050000000000000000",
         "slash_fraction_downtime": "0.010000000000000000"
       },

--- a/gaia-flex/config/genesis.json
+++ b/gaia-flex/config/genesis.json
@@ -2551,8 +2551,8 @@
       "missed_blocks": {},
       "params": {
         "downtime_jail_duration": "600000000000",
-        "min_signed_per_window": "0.500000000000000000",
-        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.050000000000000000",
+        "signed_blocks_window": "10000",
         "slash_fraction_double_sign": "0.050000000000000000",
         "slash_fraction_downtime": "0.010000000000000000"
       },


### PR DESCRIPTION
Closes #22 

Uses a similar slashing configuration as the Cosmos Hub.  Allows ~12 hour downtime before jailing.