### PR TITLE
Basic devops scripts

### DIFF
--- a/coral/defaults.env
+++ b/coral/defaults.env
@@ -1,9 +1,10 @@
 export CHAIN_ID="cosmwasm-coral"
 export TESTNET_NAME="coralnet"
 export WASMD_VERSION="v0.10.0"
+export CONFIG_DIR=".corald"
 export BINARY="corald"
-export COSMJS_VERSION="v0.22.0"
 
+export COSMJS_VERSION="v0.22.0"
 export GENESIS_URL=https://github.com/CosmWasm/testnets/raw/master/coral/config/genesis.json
 
 export RPC="https://rpc.coralnet.cosmwasm.com"

--- a/coral/defaults.env
+++ b/coral/defaults.env
@@ -5,7 +5,7 @@ export CONFIG_DIR=".corald"
 export BINARY="corald"
 
 export COSMJS_VERSION="v0.22.0"
-export GENESIS_URL=https://github.com/CosmWasm/testnets/raw/master/coral/config/genesis.json
+export GENESIS_URL="https://raw.githubusercontent.com/CosmWasm/testnets/master/coral/config/genesis.json"
 
 export RPC="https://rpc.coralnet.cosmwasm.com"
 export LCD="https://lcd.coralnet.cosmwasm.com"

--- a/coral/defaults.env
+++ b/coral/defaults.env
@@ -10,4 +10,4 @@ export GENESIS_URL=https://github.com/CosmWasm/testnets/raw/master/coral/config/
 export RPC="https://rpc.coralnet.cosmwasm.com"
 export LCD="https://lcd.coralnet.cosmwasm.com"
 export FAUCET="https://faucet.coralnet.cosmwasm.com"
-export SEED_NODE="26c9c79dc62b5ddc753bb9fcce022fcc98b5a8cf@p2p.demo-09.cosmwasm.com:26656"
+export SEED_NODE="ec488c9215e1917e41bce5ef4b53d39ff6805166@195.201.88.9:26656"

--- a/coral/defaults.env
+++ b/coral/defaults.env
@@ -1,9 +1,12 @@
-CHAIN_ID="cosmwasm-coral"
-TESTNET_NAME="coralnet"
-WASMD_VERSION="v0.10.0"
-COSMJS_VERSION="v0.22.0"
+export CHAIN_ID="cosmwasm-coral"
+export TESTNET_NAME="coralnet"
+export WASMD_VERSION="v0.10.0"
+export BINARY="corald"
+export COSMJS_VERSION="v0.22.0"
 
-RPC="https://rpc.coralnet.cosmwasm.com"
-LCD="https://lcd.coralnet.cosmwasm.com"
-FAUCET="https://faucet.coralnet.cosmwasm.com"
-SEED_NODE="26c9c79dc62b5ddc753bb9fcce022fcc98b5a8cf@p2p.demo-09.cosmwasm.com:26656"
+export GENESIS_URL=https://github.com/CosmWasm/testnets/raw/master/coral/config/genesis.json
+
+export RPC="https://rpc.coralnet.cosmwasm.com"
+export LCD="https://lcd.coralnet.cosmwasm.com"
+export FAUCET="https://faucet.coralnet.cosmwasm.com"
+export SEED_NODE="26c9c79dc62b5ddc753bb9fcce022fcc98b5a8cf@p2p.demo-09.cosmwasm.com:26656"

--- a/devops/README.md
+++ b/devops/README.md
@@ -14,6 +14,12 @@ Some changes you may wish to make if you deploy this on a value-bearing network:
 
 However, for early testnets this should be enough to get started.
 
+## Setup
+
+All scripts rely heavily on environment variables to work correctly.
+You will want to `source ../<testnetname>/defaults.env` as a basis, then
+possibly declare a few more variables as desired.
+
 ## Scripts
 
 [Full Node](./node) - will help you start up a full node connected to a running network. Once this

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,0 +1,23 @@
+# Dev Ops
+
+This contains some sample scripts that you can use to quickly pull up a node for a testnet.
+They are designed for ease of use and simplicity rather than complexity. This is just bash scripts,
+designed for Ubuntu, so they should be easy to port to any other system.
+
+Some changes you may wish to make if you deploy this on a value-bearing network:
+
+* Use native binaries rather than docker
+* Activate a firewall
+* Use hardware key signer
+* Further tune the node's config.toml
+* Further OS-level security updates
+
+However, for early testnets this should be enough to get started.
+
+## Scripts
+
+[Full Node](./node) - will help you start up a full node connected to a running network. Once this
+is synced up, you can stake to make it a validator.
+
+[Public Endpoints](./endpoints) - will help you set up ssl certs and nginx config to serve rpc and lcd
+endpoints over https. Also, you can optionally set up a faucet (if you can feed it tokens)

--- a/devops/node/README.md
+++ b/devops/node/README.md
@@ -1,0 +1,12 @@
+# Set up a Full Node
+
+## Installing
+
+First, you must get the proper testnet config, eg: `source ../coralnet/defaults.env`
+
+Then you may want to set the following variables locally:
+
+* `WASMD_HOME` - this is the directory where all the data is stored. Default `/root`
+* `REPOSITORY` - the docker image repository to use. Default `cosmwasm/wasmd` (maybe you have a fork?)
+
+The script must be run as root. If you are not logged in as root, try `sudo -E install.sh`

--- a/devops/node/README.md
+++ b/devops/node/README.md
@@ -2,11 +2,18 @@
 
 ## Installing
 
-First, you must get the proper testnet config, eg: `source ../coralnet/defaults.env`
+First, you must get the proper testnet config, eg: `source ../../coralnet/defaults.env`
 
 Then you may want to set the following variables locally:
 
+* `MONIKER` - this is the moniker you use for the node. it should be unique and descriptive (required)
 * `WASMD_HOME` - this is the directory where all the data is stored. Default `/root`
 * `REPOSITORY` - the docker image repository to use. Default `cosmwasm/wasmd` (maybe you have a fork?)
 
 The script must be run as root. If you are not logged in as root, try `sudo -E install.sh`
+
+Running this will set up all dependencies and create a local wasmd config for the proper testnet.
+
+## Systemd
+
+If you wish to run this under systemd, then run `services.sh` to set up a default config to auto-restart the node.

--- a/devops/node/README.md
+++ b/devops/node/README.md
@@ -1,14 +1,26 @@
 # Set up a Full Node
 
+These instructions work for a machine running Ubuntu 20.04.
+
+First, copy all files from this directory to the machine:
+
+`scp ./* root@1.2.3.4:`
+
+Also, copy the proper env for the testnet you choose:
+
+`scp ../../coralnet/defaults.env root@1.2.3.4:`
+
 ## Installing
 
-First, you must get the proper testnet config, eg: `source ../../coralnet/defaults.env`
+First, source all the defaults: `source defaults.sh`
 
 Then you may want to set the following variables locally:
 
 * `MONIKER` - this is the moniker you use for the node. it should be unique and descriptive (required)
 * `WASMD_HOME` - this is the directory where all the data is stored. Default `/root`
 * `REPOSITORY` - the docker image repository to use. Default `cosmwasm/wasmd` (maybe you have a fork?)
+
+Then run it like: `MONIKER=my-name-here ./install.sh`
 
 The script must be run as root. If you are not logged in as root, try `sudo -E install.sh`
 
@@ -24,6 +36,13 @@ You will want to set one or more of the following, all under `[p2p]`:
 * `seeds` - a seed node to connect to for other peers
 * `persistent_peers` - a peer to connect with everytime we restart
 * `private_peers` - node_ids from above nodes that we do not want to gossip
+
+You can use `$SEED_NODE` (from `defaults.env`) as either a seed (preferred) or a persistent peer
+in order to get attached.
+
+You can do something like this to find the node id: 
+
+`docker run --rm --mount type=bind,source=/root,target=/root cosmwasm/wasmd:v0.10.0 corald tendermint show-node-id`
 
 ## Systemd
 

--- a/devops/node/README.md
+++ b/devops/node/README.md
@@ -14,6 +14,21 @@ The script must be run as root. If you are not logged in as root, try `sudo -E i
 
 Running this will set up all dependencies and create a local wasmd config for the proper testnet.
 
+## Configuring
+
+You will want to set up some nodes to connect to. The simplest (and restart safest) way to do so
+is to edit `config/config.toml` in your chain-specific config dir.
+
+You will want to set one or more of the following, all under `[p2p]`:
+
+* `seeds` - a seed node to connect to for other peers
+* `persistent_peers` - a peer to connect with everytime we restart
+* `private_peers` - node_ids from above nodes that we do not want to gossip
+
 ## Systemd
 
 If you wish to run this under systemd, then run `services.sh` to set up a default config to auto-restart the node.
+This will install a service file with the binary name under eg `/etc/systemd/system/corald.service`,
+enable it to start on reboot, and then start it running.
+
+You may also run this manually or use another supervisor and skip this step. 

--- a/devops/node/install.sh
+++ b/devops/node/install.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 # set all variables
 REPOSITORY=${REPOSITORY:-cosmwasm/wasmd}
 DOCKER="$REPOSITORY:$WASMD_VERSION"
-
 WASMD_HOME="${WASMD_HOME:-/root}"
+
+if [ -z "$MONIKER" ]; then 
+    echo You must set MONIKER to a unique node description
+    exit 1
+fi
 
 # install deps
 apt update
@@ -15,10 +19,10 @@ docker pull $DOCKER
 # set up the private data
 docker run --rm  \
     --mount type=bind,source="$WASMD_HOME",target=/root \
-    $DOCKER $BINARY init
+    $DOCKER $BINARY init "$MONIKER"
 
 # and get the genesis file
-curl -sSL "$GENESIS_URL" > "{$WASM_HOME}/config/genesis.json"
+curl -sSL "$GENESIS_URL" > "${WASMD_HOME}/${CONFIG_DIR}/config/genesis.json"
 
 # TODO: do this more selectively
 # disable firewall completely so all p2p/rpc ports are open

--- a/devops/node/install.sh
+++ b/devops/node/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# set all variables
+REPOSITORY=${REPOSITORY:-cosmwasm/wasmd}
+DOCKER="$REPOSITORY:$WASMD_VERSION"
+
+WASMD_HOME="${WASMD_HOME:-/root}"
+
+# install deps
+apt update
+apt install -y docker.io
+docker pull $DOCKER
+
+# set up the private data
+docker run --rm  \
+    --mount type=bind,source="$WASMD_HOME",target=/root \
+    $DOCKER $BINARY init
+
+# and get the genesis file
+curl -sSL "$GENESIS_URL" > "{$WASM_HOME}/config/genesis.json"
+
+# TODO: do this more selectively
+# disable firewall completely so all p2p/rpc ports are open
+ufw disable

--- a/devops/node/services.sh
+++ b/devops/node/services.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# set all variables
+REPOSITORY=${REPOSITORY:-cosmwasm/wasmd}
+DOCKER="$REPOSITORY:$WASMD_VERSION"
+WASMD_HOME="${WASMD_HOME:-/root}"
+
+TARGET="/etc/systemd/system/${BINARY}.service"
+
+# copy service file and customize it
+mv ./wasmd.service "${TARGET}"
+sed -i "s/BINARY/$BINARY/g" "${TARGET}"
+# use , as separator, as $DOCKER and $WASMD_HOME use / internally
+sed -i "s,DOCKER,$DOCKER,g" "${TARGET}"
+sed -i "s,WASMD_HOME,$WASMD_HOME,g" "${TARGET}"
+
+systemctl enable "${BINARY}"
+systemctl start "${BINARY}"

--- a/devops/node/wasmd.service
+++ b/devops/node/wasmd.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=BINARY
+Requires=network-online.target
+After=network-online.target
+Requires=docker.service
+After=docker.service
+
+[Service]
+TimeoutStartSec=5
+Restart=always
+User=root
+Group=root
+ExecStart=/usr/bin/docker run --rm --name BINARY --mount type=bind,source=WASMD_HOME,target=/root -p 26657:26657 -p 26656:26656 DOCKER BINARY start --rpc.laddr tcp://0.0.0.0:26657 --trace
+ExecStop=/usr/bin/docker stop -t 2 BINARY
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Closes #20 

This adds some basic scripts people can use to set up the node.

You can `scp` them onto your node and then run them there to get the services going.
Or just look at them and use them as reference for building your own setup.