### PR TITLE
Deploy public endpoints

### DIFF
--- a/coral/defaults.env
+++ b/coral/defaults.env
@@ -3,6 +3,7 @@ export TESTNET_NAME="coralnet"
 export WASMD_VERSION="v0.10.0"
 export CONFIG_DIR=".corald"
 export BINARY="corald"
+export CLI_BINARY="coral"
 
 export COSMJS_VERSION="v0.22.0"
 export GENESIS_URL="https://raw.githubusercontent.com/CosmWasm/testnets/master/coral/config/genesis.json"

--- a/devops/README.md
+++ b/devops/README.md
@@ -26,4 +26,7 @@ possibly declare a few more variables as desired.
 is synced up, you can stake to make it a validator.
 
 [Public Endpoints](./endpoints) - will help you set up ssl certs and nginx config to serve rpc and lcd
-endpoints over https. Also, you can optionally set up a faucet (if you can feed it tokens)
+endpoints over https.
+
+[Faucet](./faucet) - Also, you can optionally set up a faucet. However, you need to feed it with tokens
+so it has something to give out.

--- a/devops/endpoints/README.md
+++ b/devops/endpoints/README.md
@@ -1,0 +1,43 @@
+# Public Endpoints
+
+This will set up an rpc and an lcd server behind https, using nginx as a proxy. Also handling CORS issues.
+
+You need to first have access to an RPC endpoint, either on this machine, or another machine
+you own. Check out [setting up a full node](`../node`) to see how to run your own node and
+expose an RPC endpoint.
+
+First, copy all files from this directory to the machine:
+
+`scp ./* root@1.2.3.4:`
+
+Also, copy the proper env for the testnet you choose:
+
+`scp ../../coralnet/defaults.env root@1.2.3.4:`
+
+# Rest Server
+
+We will run a rest server locally, which connects to the rpc server above and presents a
+nicer API for Javascript clients.
+
+First, source all the defaults: `source defaults.env`
+
+Then you may want to set the following variables locally:
+
+* `RPC_URL` - this is the RPC URL we connect to for serving the data. It should be trusted (required)
+* `WASMD_HOME` - this is the directory where all the data is stored. Default `/root`
+
+Then run it like: `RPC_URL=http://localhost:26657 ./rest_server.sh`
+
+When this is up, `systemctl status coral-rest` or whatever testnet it is for, should show success.
+And `curl http://localhost:1317/node_info` should return good results.
+
+
+# Nginx
+
+First, source all the defaults: `source defaults.sh`
+
+Then you may want to set the following variables locally:
+
+* `MONIKER` - this is the moniker you use for the node. it should be unique and descriptive (required)
+* `WASMD_HOME` - this is the directory where all the data is stored. Default `/root`
+* `REPOSITORY` - the docker image repository to use. Default `cosmwasm/wasmd` (maybe you have a fork?)

--- a/devops/endpoints/README.md
+++ b/devops/endpoints/README.md
@@ -8,7 +8,7 @@ expose an RPC endpoint.
 
 First, copy all files from this directory to the machine:
 
-`scp ./* root@1.2.3.4:`
+`scp -r ./* root@1.2.3.4:`
 
 Also, copy the proper env for the testnet you choose:
 
@@ -31,13 +31,29 @@ Then run it like: `RPC_URL=http://localhost:26657 ./rest_server.sh`
 When this is up, `systemctl status coral-rest` or whatever testnet it is for, should show success.
 And `curl http://localhost:1317/node_info` should return good results.
 
-
 # Nginx
 
-First, source all the defaults: `source defaults.sh`
+You should already have the rest server running locally, and the `defaults.env` variables in your shell.
 
-Then you may want to set the following variables locally:
+Then you will want to set the following variables locally:
 
-* `MONIKER` - this is the moniker you use for the node. it should be unique and descriptive (required)
-* `WASMD_HOME` - this is the directory where all the data is stored. Default `/root`
-* `REPOSITORY` - the docker image repository to use. Default `cosmwasm/wasmd` (maybe you have a fork?)
+* `EMAIL` - an email for a sysadmin, used with let's encrypt when registering ssl certificates
+* `DOMAIN` - the root domain we register under. We will try to set up ssl services for
+  `rpc.$DOMAIN` and `lcd.$DOMAIN`. Both these DNS records must point to the current machine
+* `RPC_URL` - this is the RPC URL we connect to for serving the data. (same one the rest server uses)
+
+Run it like:
+
+```bash
+export EMAIL=hello@my.com
+export DOMAIN=coral.my.com
+export RPC_URL=http://localhost:26657/
+./nginx.sh
+```
+
+After this is done, you should be able to query the https endpoints:
+
+```bash
+curl https://rpc.DOMAIN/status
+curl https://lcd.DOMAIN/node_info
+```

--- a/devops/endpoints/nginx.sh
+++ b/devops/endpoints/nginx.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+apt install -y nginx certbot python3-certbot-nginx
+
+echo n | certbot register --agree-tos -m ${EMAIL}
+certbot certonly --nginx -n -d rpc.${DOMAIN}
+certbot certonly --nginx -n -d lcd.${DOMAIN}
+
+# process the variables in sites-enabled
+for file in $(ls nginx | grep -v proxy); do
+    FILE="nginx/${file}"
+    sed -i s/DOMAIN/${DOMAIN}/g $FILE
+    sed -i s,RPC_URL,${RPC_URL},g $FILE
+done  
+
+# copy over nginx configs
+mv ./nginx/proxy.conf /etc/nginx/conf.d
+mv ./nginx/*.conf /etc/nginx/sites-enabled
+
+nginx -t
+systemctl restart nginx

--- a/devops/endpoints/nginx/lcd.conf
+++ b/devops/endpoints/nginx/lcd.conf
@@ -1,0 +1,43 @@
+server { # lcd
+    listen       80;
+    server_name  lcd.DOMAIN;
+    access_log   /var/log/nginx/lcd_http.access.log;
+
+    return 301 https://$host$request_uri;
+}
+
+server { # lcd
+    listen       443 ssl;
+    server_name  lcd.DOMAIN;
+    access_log   /var/log/nginx/lcd.access.log;
+
+    ssl_certificate /etc/letsencrypt/live/lcd.DOMAIN/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/lcd.DOMAIN/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    add_header Access-Control-Allow-Origin * always;
+    add_header Access-Control-Max-Age 3600;
+    add_header Access-Control-Allow-Credentials true always;
+    add_header Access-Control-Allow-Headers Content-Type;
+
+    location / {
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            #
+            # Custom headers and headers various browsers *should* be OK with but aren't
+            #
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            #
+            # Tell client that this pre-flight info is valid for 20 days
+            #
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+
+        proxy_pass http://localhost:1317/;
+    }
+}

--- a/devops/endpoints/nginx/proxy.conf
+++ b/devops/endpoints/nginx/proxy.conf
@@ -1,0 +1,10 @@
+proxy_redirect          off;
+proxy_set_header        Host            $host;
+proxy_set_header        X-Real-IP       $remote_addr;
+proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+client_max_body_size    10m;
+client_body_buffer_size 128k;
+proxy_connect_timeout   90;
+proxy_send_timeout      90;
+proxy_read_timeout      90;
+proxy_buffers           32 4k;

--- a/devops/endpoints/nginx/rpc.conf
+++ b/devops/endpoints/nginx/rpc.conf
@@ -1,0 +1,43 @@
+server { # rpc
+    listen       80;
+    server_name  rpc.DOMAIN;
+    access_log   /var/log/nginx/rpc_http.access.log;
+
+    return 301 https://$host$request_uri;
+}
+
+server { # rpc
+    listen       443 ssl;
+    server_name  rpc.DOMAIN;
+    access_log   /var/log/nginx/rpc.access.log;
+
+    ssl_certificate /etc/letsencrypt/live/rpc.DOMAIN/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/rpc.DOMAIN/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    add_header Access-Control-Allow-Origin * always;
+    add_header Access-Control-Max-Age 3600;
+    add_header Access-Control-Allow-Credentials true always;
+    add_header Access-Control-Allow-Headers Content-Type;
+
+    location / {
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            #
+            # Custom headers and headers various browsers *should* be OK with but aren't
+            #
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            #
+            # Tell client that this pre-flight info is valid for 20 days
+            #
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+
+        proxy_pass RPC_URL;
+    }
+}

--- a/devops/endpoints/rest_server.sh
+++ b/devops/endpoints/rest_server.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# set all variables
+REPOSITORY=${REPOSITORY:-cosmwasm/wasmd}
+DOCKER="$REPOSITORY:$WASMD_VERSION"
+WASMD_HOME="${WASMD_HOME:-/root}"
+
+if [ -z "$RPC_URL" ]; then 
+    echo "You must set RPC_URL to an RPC endpoint"
+    exit 1
+fi
+
+echo "Connecting rest server to $RPC_URL"
+
+# install deps if needed
+apt install -y docker.io
+docker pull $DOCKER
+
+SERVICE="${CLI_BINARY}-rest"
+TARGET="/etc/systemd/system/${SERVICE}.service"
+
+# copy service file and customize it
+mv ./wasm-rest.service "${TARGET}"
+sed -i "s/BINARY/$CLI_BINARY/g" "${TARGET}"
+sed -i "s/SERVICE/$SERVICE/g" "${TARGET}"
+# use , as separator, as $DOCKER and $WASMD_HOME use / internally
+sed -i "s,DOCKER,$DOCKER,g" "${TARGET}"
+sed -i "s,WASMD_HOME,$WASMD_HOME,g" "${TARGET}"
+sed -i "s,RPC_URL,$RPC_URL,g" "${TARGET}"
+
+systemctl enable "${SERVICE}"
+systemctl start "${SERVICE}"
+

--- a/devops/endpoints/wasm-rest.service
+++ b/devops/endpoints/wasm-rest.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SERVICE
+Requires=network-online.target
+After=network-online.target
+Requires=docker.service
+After=docker.service
+
+[Service]
+TimeoutStartSec=5
+Restart=always
+User=root
+Group=root
+ExecStart=/usr/bin/docker run --rm --name SERVICE --mount type=bind,source=WASMD_HOME,target=/root --network=host -p 1317:1317 DOCKER BINARY rest-server --laddr tcp://127.0.0.1:1317 --trust-node --node RPC_URL
+ExecStop=/usr/bin/docker stop -t 2 SERVICE
+
+[Install]
+WantedBy=multi-user.target
+

--- a/devops/node/README.md
+++ b/devops/node/README.md
@@ -38,11 +38,10 @@ You will want to set one or more of the following, all under `[p2p]`:
 * `private_peers` - node_ids from above nodes that we do not want to gossip
 
 You can use `$SEED_NODE` (from `defaults.env`) as either a seed (preferred) or a persistent peer
-in order to get attached.
+in order to get attached. These all look like `${node_id}@${ip}:${port}`. Node_id is a hash of the
+public key, so you can recognize the same machine if it moves ips.
 
-You can do something like this to find the node id: 
-
-`docker run --rm --mount type=bind,source=/root,target=/root cosmwasm/wasmd:v0.10.0 corald tendermint show-node-id`
+To get the `node_id` of your current node, run `./node_id.sh`
 
 ## Systemd
 
@@ -50,4 +49,4 @@ If you wish to run this under systemd, then run `services.sh` to set up a defaul
 This will install a service file with the binary name under eg `/etc/systemd/system/corald.service`,
 enable it to start on reboot, and then start it running.
 
-You may also run this manually or use another supervisor and skip this step. 
+You may also run this manually or use another supervisor and skip this step.

--- a/devops/node/README.md
+++ b/devops/node/README.md
@@ -4,7 +4,7 @@ These instructions work for a machine running Ubuntu 20.04.
 
 First, copy all files from this directory to the machine:
 
-`scp ./* root@1.2.3.4:`
+`scp -r ./* root@1.2.3.4:`
 
 Also, copy the proper env for the testnet you choose:
 

--- a/devops/node/node_id.sh
+++ b/devops/node/node_id.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# set all variables
+REPOSITORY=${REPOSITORY:-cosmwasm/wasmd}
+DOCKER="$REPOSITORY:$WASMD_VERSION"
+WASMD_HOME="${WASMD_HOME:-/root}"
+
+docker run --rm  \
+    --mount type=bind,source="$WASMD_HOME",target=/root \
+    $DOCKER $BINARY tendermint show-node-id


### PR DESCRIPTION
Fixes much of #21  (except faucet)

Tested and used to deploy 

* https://rpc.coralnet.cosmwasm.com/status
* https://lcd.coralnet.cosmwasm.com/node_info
