### PR TITLE
Add entry to genesis with my gaia address

### DIFF
--- a/gaia-flex/config/genesis.json
+++ b/gaia-flex/config/genesis.json
@@ -2477,6 +2477,21 @@
             "public_key": null,
             "sequence": "0"
           }
+        },
+        {
+          "type": "cosmos-sdk/Account",
+          "value": {
+            "account_number": "0",
+            "address": "cosmos17fzz8v57p4uajhn2peysjgavyvveky2vnpemg6",
+            "coins": [
+              {
+                "amount": "10000000000",
+                "denom": "umuon"
+              }
+            ],
+            "public_key": null,
+            "sequence": "0"
+          }
         }
       ],
       "params": {


### PR DESCRIPTION
Adding this to let us debug. Add a key owned by `gaiacli`, so I can document the import method (the addresses we used are from cosmos hub mainnet, not from gaia-flex, so this may be  abit tricky)