### PR TITLE
devops: fix big-dipper installation

### DIFF
--- a/devops/big-dipper/install.sh
+++ b/devops/big-dipper/install.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 apt update
 apt install -y docker.io docker-compose jq
 
+docker-compose pull
+
 METEOR_SETTINGS=$(jq -c < ./settings.json)
 APP_ROOT_URL="https://bigdipper.${DOMAIN}"
 


### PR DESCRIPTION
docker-compose `systemd` startup fails due to pull stage taking long. Pulling before running fixes the problem.