### PR TITLE
Fix wrong denom in gas prices argument

### DIFF
--- a/sandynet-1/defaults.env
+++ b/sandynet-1/defaults.env
@@ -21,4 +21,4 @@ export COSMOVISOR_HOME=/root/.wasmd
 export COSMOVISOR_NAME=wasmd
 
 export NODE=(--node $RPC)
-export TXFLAG=($NODE --chain-id $CHAIN_ID --gas-prices 0.001usandy --gas auto --gas-adjustment 1.3)
+export TXFLAG=($NODE --chain-id $CHAIN_ID --gas-prices 0.001ubay --gas auto --gas-adjustment 1.3)


### PR DESCRIPTION
Change `usandy` to `ubay` for `--gas-prices` argument.

## Use case
Send transfer using this command:
```
wasmd tx send --from wallet wasm1yynfr9grye674aj8taq5klrm8q8n7zerhrpuym wasm1cqdzj9pfegn74fq7ssltlxj3z4q6hf24dhyu9k 1000000ubay $TXFLAG
```
## Expected behavior
Sending transactions using the `defaults.env` variables should work.

## Actual behavior
Sending transactions using the `defaults.env` variables fail with error:
```json
{
   "txhash":"56524701FFD9C3CCC71A961AC1410DC70C04329C6C6218AFF4BA7F08ADFDA87B",
   "codespace":"sdk",
   "code":13,
   "raw_log":"insufficient fees; got: 72usandy required: 72ubay: insufficient fee",
   "gas_wanted":"71737",
   "gas_used":"3396"
}
```

## Changes summary

Change : 
```
export TXFLAG=($NODE --chain-id $CHAIN_ID --gas-prices 0.001usandy --gas auto --gas-adjustment 1.3)
```
To:
```
export TXFLAG=($NODE --chain-id $CHAIN_ID --gas-prices 0.001ubay --gas auto --gas-adjustment 1.3)
```

